### PR TITLE
Disable hotkey for `project-find:show`

### DIFF
--- a/keymaps/find-and-replace.cson
+++ b/keymaps/find-and-replace.cson
@@ -1,10 +1,10 @@
 '.platform-darwin':
-  'cmd-F': 'project-find:show'
+  # 'cmd-F': 'project-find:show'
   'cmd-f': 'find-and-replace:show'
   'cmd-alt-f': 'find-and-replace:show-replace'
 
 '.platform-win32, .platform-linux':
-  'ctrl-F': 'project-find:show'
+  # 'ctrl-F': 'project-find:show'
   'ctrl-f': 'find-and-replace:show'
   'ctrl-alt-f': 'find-and-replace:show-replace'
 


### PR DESCRIPTION
Bearing in mind that many people have reported losing hours of work to bug #331, and that those people are only a subset of the people affected, it seems likely that hours of work are being lost per day.

While this solution is not ideal, replacing in the whole project is not a common operation, so removing its hotkey will likely cause less time to be wasted than if we kept the hotkey.

I know this may seem like a poor solution, but please don't reject this PR unless you really believe that the hotkey is saving more time than it's costing, or if you're going to add a better solution very soon.

Thanks.
